### PR TITLE
Step 2: Setup code coverage reports for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ _ide_helper_models.php
 /storage/medialibrary/temp
 /storage/media-library/temp
 .php_cs.cache
+.phpunit.result.cache
+/build/

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,13 +20,13 @@
   </logging>
   <testsuites>
     <testsuite name="Default">
-      <directory suffix="Test.php">./tests/</directory>
+      <directory>./tests/</directory>
     </testsuite>
     <testsuite name="Unit">
-      <directory suffix="Test.php">./tests/Unit</directory>
+      <directory>./tests/Unit</directory>
     </testsuite>
     <testsuite name="Feature">
-      <directory suffix="Test.php">./tests/Feature</directory>
+      <directory>./tests/Feature</directory>
     </testsuite>
   </testsuites>
   <php>
@@ -34,7 +34,7 @@
     <server name="BCRYPT_ROUNDS" value="4"/>
     <server name="CACHE_DRIVER" value="array"/>
     <server name="DB_CONNECTION" value="mysql"/>
-    <server name="DB_DATABASE" value="spatie.be"/>
+    <server name="DB_DATABASE" value="spatie_tests"/>
     <server name="MAIL_MAILER" value="array"/>
     <server name="QUEUE_CONNECTION" value="sync"/>
     <server name="SESSION_DRIVER" value="array"/>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,10 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         verbose="true"
+>
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">./app</directory>
     </include>
+    <report>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
   </coverage>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
   <testsuites>
     <testsuite name="Default">
       <directory suffix="Test.php">./tests/</directory>
@@ -21,7 +34,7 @@
     <server name="BCRYPT_ROUNDS" value="4"/>
     <server name="CACHE_DRIVER" value="array"/>
     <server name="DB_CONNECTION" value="mysql"/>
-    <server name="DB_DATABASE" value="spatie_tests"/>
+    <server name="DB_DATABASE" value="spatie.be"/>
     <server name="MAIL_MAILER" value="array"/>
     <server name="QUEUE_CONNECTION" value="sync"/>
     <server name="SESSION_DRIVER" value="array"/>


### PR DESCRIPTION
– Add reporting
– Add logging
– Add non-redundant attributes from _Spatie_ templates
– Remove redundant "Test.php" attributes