### PR TITLE
Step 3: Charset in Css must be double-quoted

### DIFF
--- a/resources/css/front/front.css
+++ b/resources/css/front/front.css
@@ -1,4 +1,4 @@
-@charset 'UTF-8';
+@charset "UTF-8";
 
 @import './bootstrap.css';
 @import './highlight.css';


### PR DESCRIPTION
charset
Is a <string> denoting the character encoding to be used. It must be the name of a web-safe character encoding defined in the IANA-registry, **and must be double-quoted**, following exactly one space character (U+0020), and immediately terminated with a semicolon. If several names are associated with an encoding, only the one marked with preferred must be used.

https://developer.mozilla.org/en-US/docs/Web/CSS/@charset